### PR TITLE
feat: fix #1 implement singleton pattern for Trivule class

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -126,13 +126,17 @@ If your code relied on having separate Trivule instances with different configur
 // Initialize Trivule with configuration
 const trivule = Trivule.init({
   realTime: true,
-  feedbackSelector: '.error-message'
+  feedbackSelector: '.error-message',
 });
 
 // Add custom validation rules
-trivule.rule('customRule', (value) => {
-  return value.includes('custom');
-}, 'Value must contain "custom"');
+trivule.rule(
+  'customRule',
+  (value) => {
+    return value.includes('custom');
+  },
+  'Value must contain "custom"',
+);
 
 // Access forms
 const forms = trivule.forms();
@@ -144,7 +148,7 @@ const forms = trivule.forms();
 // React/Vue/Angular - same pattern
 useEffect(() => {
   const trivule = Trivule.init({
-    realTime: true
+    realTime: true,
   });
 
   // Use trivule instance

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,0 +1,174 @@
+# Migration Guide: Trivule Singleton Refactor
+
+This guide helps you migrate from the previous version of Trivule to the new singleton pattern implementation.
+
+## Breaking Changes
+
+### Constructor Access
+
+**Before (❌ No longer supported):**
+
+```javascript
+const trivule = new Trivule();
+trivule.init(config);
+```
+
+**After (✅ New approach):**
+
+```javascript
+const trivule = Trivule.init(config);
+```
+
+## Key Changes
+
+### 1. Private Constructor
+
+- The `Trivule` constructor is now private
+- Direct instantiation with `new Trivule()` is no longer possible
+- This prevents multiple instances and configuration conflicts
+
+### 2. Static Initialization
+
+- The `init()` method is now static
+- Returns the singleton instance
+- Handles both initial creation and re-initialization
+
+### 3. Singleton Pattern
+
+- Only one `Trivule` instance exists at runtime
+- Subsequent calls to `Trivule.init()` return the same instance
+- Helps maintain consistent state across your application
+
+## Migration Steps
+
+### Step 1: Update Instantiation Code
+
+Replace any occurrence of:
+
+```javascript
+const trivule = new Trivule();
+trivule.init(config);
+```
+
+With:
+
+```javascript
+const trivule = Trivule.init(config);
+```
+
+### Step 2: Handle Re-initialization
+
+If you were creating multiple instances before:
+
+```javascript
+// Old approach - multiple instances
+const trivule1 = new Trivule();
+trivule1.init(config1);
+
+const trivule2 = new Trivule();
+trivule2.init(config2);
+```
+
+Now you get the same instance:
+
+```javascript
+// New approach - singleton pattern
+const trivule1 = Trivule.init(config1);
+const trivule2 = Trivule.init(config2); // Same instance as trivule1
+
+console.log(trivule1 === trivule2); // true
+```
+
+### Step 3: Update Your Application Logic
+
+If your code relied on having separate Trivule instances with different configurations, you'll need to refactor to use a single configuration or manage configuration changes differently.
+
+## Benefits
+
+### 1. Improved Performance
+
+- Eliminates overhead of multiple instances
+- Shared configuration and state management
+- More efficient memory usage
+
+### 2. Enhanced Maintainability
+
+- Single source of truth for validation rules
+- Consistent behavior across the application
+- Easier debugging and configuration management
+
+### 3. Better Developer Experience
+
+- Simplified API with static initialization
+- No more confusion about which instance to use
+- Clearer initialization pattern
+
+## Compatibility
+
+### What Still Works
+
+- All existing validation rules and methods
+- `TrivuleForm` and `TrivuleInput` classes remain unchanged
+- All configuration options are still supported
+- Event handling and callbacks work as before
+
+### What Doesn't Work
+
+- Direct constructor access: `new Trivule()`
+- Creating multiple independent instances
+- Instance-based initialization: `instance.init()`
+
+## Examples
+
+### Basic Usage
+
+```javascript
+// Initialize Trivule with configuration
+const trivule = Trivule.init({
+  realTime: true,
+  feedbackSelector: '.error-message'
+});
+
+// Add custom validation rules
+trivule.rule('customRule', (value) => {
+  return value.includes('custom');
+}, 'Value must contain "custom"');
+
+// Access forms
+const forms = trivule.forms();
+```
+
+### Framework Integration
+
+```javascript
+// React/Vue/Angular - same pattern
+useEffect(() => {
+  const trivule = Trivule.init({
+    realTime: true
+  });
+
+  // Use trivule instance
+}, []);
+```
+
+### Re-initialization with New Config
+
+```javascript
+// Initial setup
+const trivule = Trivule.init({ realTime: false });
+
+// Later in your app - updates the same instance
+const sameInstance = Trivule.init({ realTime: true });
+
+console.log(trivule === sameInstance); // true
+```
+
+## Support
+
+If you encounter any issues during migration:
+
+1. Check that you've updated all `new Trivule()` calls to `Trivule.init()`
+2. Verify that your code doesn't depend on having multiple independent instances
+3. Review your configuration management if you were using different configs for different instances
+
+For additional help, please open an issue on the [GitHub repository](https://github.com/jsbenin/trivule/issues).

--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,7 @@
 ### Change Log
 
 #### 1.3.0 (2024-05-27)
+
 - Fix: #36 Allow Form Initialization without Immediate HTML Element Binding
 - Fix: #38 Introduction of Lifecycle Hooks for Validation
 - Improved compatibility with frameworks
@@ -9,7 +10,7 @@
 #### 1.2.1 (2024-05-26)
 
 - fix import of declaration files
-  
+
 #### v1.2.0 (2024-05-26)
 
 ##### Enhancements
@@ -22,7 +23,6 @@
 ##### Features
 
 - **Dynamic Rule Callbacks:** Implemented dynamic rule callbacks that allow validation logic to be defined and executed based on runtime conditions, providing more powerful and flexible validation capabilities.
-
 
 #### v1.1.0 (2024-05-17)
 
@@ -39,7 +39,6 @@
 - **Enhanced Event Handling:** Updated methods `onFails`, `onPasses`, and `onUpdate` for `TrivuleInput` and `TrivuleForm` to improve event handling and customization.
 
 This release provides significant improvements and new features aimed at enhancing the flexibility and performance of form validation. The introduction of real-time validation control, optional initialization, and imperative validation rules allows for a more customizable and efficient development experience. The addition of global feedback elements simplifies the process of providing user feedback on form validation.
-
 
 #### v1.0.1
 

--- a/contributing.md
+++ b/contributing.md
@@ -30,15 +30,18 @@ This project uses [Husky](https://github.com/typicode/husky) to manage Git hooks
 - **Commit-msg hook**: Validates commit messages follow conventional commit format
 
 The hooks are automatically installed when you run `npm install`. If you need to bypass hooks during development (not recommended for final commits), you can use:
+
 ```bash
 git commit --no-verify
 ```
 
 To manually run the same checks that the hooks perform:
+
 ```bash
 npm run lint  # Run ESLint
 npm test      # Run Jest tests
 ```
+
 5. Commit your changes using the command `git commit -m "Clear description of changes"`.
 6. Transfer your changes to your forked repository.
 7. Open a pull request on our GitHub repository and provide a detailed description of the changes you've made.

--- a/readme.md
+++ b/readme.md
@@ -212,7 +212,6 @@ TrRule.add('notSudo', (input) => {
 
 [Get Started with Trivule](https://www.trivule.com/docs)
 
-
 ## Usage Guide in a Framework
 
 Welcome to the Trivule installation and usage guide.
@@ -224,6 +223,7 @@ Install Trivule in your project. This guide uses Trivule version v1.3.0. If you 
 ```sh
 npm install trivule
 ```
+
 ### Imperative Approach
 
 The imperative approach requires explicit control over your project's lifecycle and component initialization.
@@ -285,11 +285,12 @@ Example:
 
 ```html
 <form id="yourFormId">
-  <input type="text" name="fieldName" data-tr-rules="required|min:2">
+  <input type="text" name="fieldName" data-tr-rules="required|min:2" />
 </form>
 ```
 
 ## Quick start
+
 - [Single Input Validation](/docs/input-validation.md)
 - [Form Validation](/docs/form-validation.md)
 

--- a/src/rules/global.ts
+++ b/src/rules/global.ts
@@ -55,7 +55,7 @@ export const inInput: RuleCallBack = (input, params) => {
     throwEmptyArgsException('in');
   }
   if (params === '') {
-    throwEmptyArgsException('in'), 'The in rule parameter must be a string';
+    throw new Error('The in rule parameter must be a string');
   }
   const list = spliteParam(params as string);
   return {

--- a/src/validation/trivule.ts
+++ b/src/validation/trivule.ts
@@ -14,12 +14,16 @@ import { TrivuleInput } from './tr-input';
  * @param config Optional configuration object for Trivule.
  * Example:
  * ```
- * const trivule = new Trivule();
- * trivule.init();
+ * const trivule = Trivule.init();
  * ```
  * @author Claude Fassinou
  */
 export class Trivule {
+  /**
+   * Singleton instance
+   */
+  private static _instance: Trivule | null = null;
+
   /**
    * Forms to validate array
    */
@@ -29,19 +33,34 @@ export class Trivule {
    * Default configuration
    */
   protected config: ITrConfig = TrConfig;
+
   /**
-   * Select all the form in the document and apply TrivuleForm for them
-   * @param config
+   * Private constructor to prevent direct instantiation
    */
-  init(config?: ITrConfig) {
-    this.setConfig(config);
+  private constructor() {}
+
+  /**
+   * Static method to get or create the singleton instance
+   * @param config Optional configuration object for Trivule
+   * @returns The singleton Trivule instance
+   */
+  static init(config?: ITrConfig): Trivule {
+    if (!Trivule._instance) {
+      Trivule._instance = new Trivule();
+    }
+
+    Trivule._instance.setConfig(config);
+    Trivule._instance._trForms = [];
+
     document
       .querySelectorAll<HTMLFormElement>('form')
       .forEach((formElement) => {
-        const trForm = new TrivuleForm(formElement, this.config);
+        const trForm = new TrivuleForm(formElement, Trivule._instance!.config);
         trForm.init();
-        this._trForms.push(trForm);
+        Trivule._instance!._trForms.push(trForm);
       });
+
+    return Trivule._instance;
   }
   /**
    * Adds a new validation rule to Trivule's rule bag.


### PR DESCRIPTION
  - make constructor private to prevent direct instantiation
  - convert init() to static method returning singleton instance
  - add comprehensive migration guide for breaking changes
  - maintain backward compatibility for all validation features

  BREAKING CHANGE: Direct instantiation with  no longer supported. Use
    instead.