### PR TITLE
refactor: move TrivuleForm constructor logic to setConfig method

### DIFF
--- a/docs/form-validation.md
+++ b/docs/form-validation.md
@@ -38,7 +38,8 @@ Specify validation rules in the attributes of HTML fields for basic form validat
 **Initialization:**
 
 ```js
-const trForm = new TrivuleForm('form');
+const trForm = new TrivuleForm();
+trForm.setConfig('form');
 ```
 
 ### Imperative Validation

--- a/docs/rules/equals-and-not-equals.md
+++ b/docs/rules/equals-and-not-equals.md
@@ -24,7 +24,8 @@ Both rules accept either string or numeric values. If both the input and the par
 ```ts
 import { TrivuleForm } from 'trivule';
 
-const form = new TrivuleForm('form');
+const form = new TrivuleForm();
+form.setConfig('form');
 form.make({
   points: {
     rules: 'equals:50',

--- a/issue-trivule-form-constructor.md
+++ b/issue-trivule-form-constructor.md
@@ -1,0 +1,85 @@
+---
+name: Feature Request
+about: Refactor TrivuleForm constructor to improve initialization pattern
+title: '[FEATURE] Refactor TrivuleForm constructor - Move logic to setConfig method'
+labels: enhancement, refactoring, breaking-change
+assignees: ''
+---
+
+**Is your feature request related to a problem? Please describe.**
+Currently, the `TrivuleForm` constructor accepts complex parameters and handles multiple initialization scenarios, which makes the class instantiation complex and less predictable. The constructor handles both container/config parameter combinations, making the API confusing:
+
+```typescript
+// Current complex constructor signatures
+new TrivuleForm(containerOrConfig?, config?)
+```
+
+This leads to:
+
+- Complex constructor logic that's hard to maintain
+- Multiple initialization paths that can be confusing
+- Tight coupling between instantiation and configuration
+- Difficulty in testing different configuration scenarios
+- Inconsistent API patterns compared to other parts of the codebase
+
+**Describe the solution you'd like**
+Refactor the `TrivuleForm` class to have a parameter-less constructor and move all initialization logic to the `setConfig` method:
+
+1. **Empty Constructor**: The constructor should not accept any parameters and should only initialize basic properties
+2. **Enhanced setConfig Method**: Move the current constructor logic to `setConfig` method to handle both container and config parameters
+3. **Explicit Initialization**: After instantiation, developers must explicitly call `setConfig()` to configure the form
+4. **Cleaner API**: This creates a cleaner, more predictable initialization pattern
+
+**Proposed API:**
+
+```typescript
+// New pattern
+const trivuleForm = new TrivuleForm();
+trivuleForm.setConfig(containerOrConfig, config);
+trivuleForm.init();
+
+// Or with method chaining
+const trivuleForm = new TrivuleForm()
+  .setConfig(containerOrConfig, config)
+  .init();
+```
+
+## Describe alternatives you've considered
+
+1. **Static Factory Methods**: Create static methods like `TrivuleForm.create()` but this adds complexity
+2. **Builder Pattern**: Implement a builder pattern, but it might be overkill for this use case
+3. **Keep Current API**: Maintain the current constructor but add deprecation warnings
+
+**Additional context**
+This change would:
+
+- Simplify the constructor and make it more predictable
+- Improve testability by separating instantiation from configuration
+- Align with the overall API consistency goals of the project
+- Make the initialization flow more explicit and clear
+- Reduce constructor complexity and improve maintainability
+
+**Implementation considerations:**
+
+- This is a breaking change that requires updating all existing code
+- All tests need to be updated to use the new pattern
+- Documentation and examples must be updated
+- Consider providing a migration guide for existing users
+- Ensure backward compatibility during a transition period if needed
+
+**Breaking Changes:**
+
+- Existing code using `new TrivuleForm(params)` will need to be updated
+- All test files will require modifications
+- Integration patterns will change
+
+**Migration Pattern:**
+
+```typescript
+// Before
+const form = new TrivuleForm(element, config);
+
+// After  
+const form = new TrivuleForm();
+form.setConfig(element, config);
+```

--- a/readme.md
+++ b/readme.md
@@ -239,6 +239,7 @@ Example:
 import TrivuleForm from 'trivule';
 
 const form = new TrivuleForm();
+form.setConfig({ element: 'form' });
 
 // Define your validation rules here
 form.afterBinding((form) => {

--- a/src/core/form.ts
+++ b/src/core/form.ts
@@ -24,11 +24,11 @@ import { TrParameter } from './utils/parameter';
 /**
  * TrivuleForm is responsible for applying live validation to an HTML form.
  * Creates an instance of TrivuleForm.
- * @param formElement The HTML form element to apply live validation to.
  * Example:
  * ```
  * const formElement = document.getElementById("myForm") as HTMLFormElement;
- * const trivuleForm = new TrivuleForm(formElement);
+ * const trivuleForm = new TrivuleForm();
+ * trivuleForm.setConfig(formElement);
  * trivuleForm.init();
  * ```
  */
@@ -91,28 +91,8 @@ export class TrivuleForm {
 
   private _wasInit = false;
   private _wasBound = false;
-  constructor(
-    containerOrConfig?: ValidatableForm | TrivuleFormConfig,
-    config?: TrivuleFormConfig,
-  ) {
+  constructor() {
     this.parameter = TrParameter.instance();
-    //If the container is provided and is resolvable we bind it automatically
-    //if the container is config, we check if element attribut exists and bind it
-    //If config is provided we assign it
-    if (
-      typeof containerOrConfig === 'string' ||
-      containerOrConfig instanceof HTMLElement
-    ) {
-      this.setConfig(config);
-      this.bind(containerOrConfig);
-    } else {
-      config = config ?? containerOrConfig;
-
-      this.setConfig(config);
-      if (config?.element) {
-        this.bind(config.element);
-      }
-    }
   }
 
   setSubmitButton(selector?: CssSelector) {
@@ -133,7 +113,8 @@ export class TrivuleForm {
    * Initializes live validation on the form element.
    * Example:
    * ```
-   * const trivuleForm = new TrivuleForm(formElement);
+   * const trivuleForm = new TrivuleForm();
+   * trivuleForm.setConfig(formElement);
    * trivuleForm.init();
    * ```
    */
@@ -352,7 +333,33 @@ export class TrivuleForm {
     TrBag.rule(ruleName, call, message);
   }
 
-  protected setConfig(config?: TrivuleFormConfig) {
+  setConfig(
+    containerOrConfig?: ValidatableForm | TrivuleFormConfig,
+    config?: TrivuleFormConfig,
+  ) {
+    // Handle the logic that was previously in the constructor
+    if (
+      typeof containerOrConfig === 'string' ||
+      containerOrConfig instanceof HTMLElement
+    ) {
+      // If the first parameter is a container (string or HTMLElement)
+      this._setConfigOptions(config);
+      this.bind(containerOrConfig);
+    } else {
+      // If the first parameter is a config object (or undefined)
+      config = config ?? containerOrConfig;
+      this._setConfigOptions(config);
+      if (config?.element) {
+        this.bind(config.element);
+      }
+    }
+  }
+
+  /**
+   * Set configuration options for the form
+   * @param config Configuration options
+   */
+  private _setConfigOptions(config?: TrivuleFormConfig) {
     let lang =
       getAttrData<string | undefined>(document.querySelector('html'), 'lang') ||
       document.querySelector('html')?.getAttribute('lang');
@@ -519,7 +526,8 @@ export class TrivuleForm {
    * Example:
    * ```typescript
    * const formElement = document.getElementById("myForm") as HTMLFormElement;
-   * const trivuleForm = new TrivuleForm(formElement);
+   * const trivuleForm = new TrivuleForm();
+   * trivuleForm.setConfig(formElement);
    * trivuleForm.init();
    *
    * // Use the form...
@@ -574,7 +582,8 @@ export class TrivuleForm {
    *
    * @example
    * const formElement = document.getElementById("myForm") as HTMLFormElement;
-   * const trivuleForm = new TrivuleForm(formElement);
+   * const trivuleForm = new TrivuleForm();
+   * trivuleForm.setConfig(formElement);
    * // Configure additional parameters for an input
    * trivuleForm.with("inputName", { rules: ['required','email']});
    * trivuleForm.init();

--- a/src/core/trivule.ts
+++ b/src/core/trivule.ts
@@ -56,7 +56,8 @@ export class Trivule {
     document
       .querySelectorAll<HTMLFormElement>('form')
       .forEach((formElement) => {
-        const trForm = new TrivuleForm(formElement, Trivule._instance!.config);
+        const trForm = new TrivuleForm();
+        trForm.setConfig(formElement, Trivule._instance!.config);
         trForm.init();
         Trivule._instance!._trForms.push(trForm);
       });
@@ -100,7 +101,8 @@ export class Trivule {
     selector: ValidatableForm | TrivuleFormConfig,
     config: TrivuleFormConfig,
   ) {
-    const trForm = new TrivuleForm(selector, config);
+    const trForm = new TrivuleForm();
+    trForm.setConfig(selector, config);
     trForm.init();
     return trForm;
   }

--- a/tests/form.test.ts
+++ b/tests/form.test.ts
@@ -63,7 +63,8 @@ class MyForm {
 const formInstance = new MyForm();
 
 describe('TrivuleForm', () => {
-  const trivuleForm = new TrivuleForm(formInstance.form, {
+  const trivuleForm = new TrivuleForm();
+  trivuleForm.setConfig(formInstance.form, {
     realTime: false,
   });
   test('Test get method', () => {
@@ -127,7 +128,8 @@ describe('TrivuleForm', () => {
       expect(trForm.getNativeElement()).toBe(formInstance.form);
     });
     test('Should return the native element with config', () => {
-      trForm = new TrivuleForm({
+      trForm = new TrivuleForm();
+      trForm.setConfig({
         element: formInstance.form,
         realTime: false,
       });
@@ -135,7 +137,8 @@ describe('TrivuleForm', () => {
       expect(trForm.isRealTimeEnabled()).toBe(false);
     });
     test('Should resole inputs validations', () => {
-      trForm = new TrivuleForm({
+      trForm = new TrivuleForm();
+      trForm.setConfig({
         realTime: false,
       });
       trForm.make([
@@ -153,7 +156,8 @@ describe('TrivuleForm', () => {
       expect(trForm.isRealTimeEnabled()).toBe(false);
     });
     test('Should return the native element', () => {
-      trForm = new TrivuleForm(formInstance.form);
+      trForm = new TrivuleForm();
+      trForm.setConfig(formInstance.form);
       expect(trForm.getNativeElement()).toBe(formInstance.form);
     });
   });


### PR DESCRIPTION
BREAKING CHANGE: TrivuleForm constructor no longer accepts parameters. Use new TrivuleForm() followed by setConfig(container, config) instead.

- Remove complex logic from constructor
- Move initialization logic to setConfig method
- Update all tests to use new pattern
- Update documentation and examples
- Maintain backward compatibility in setConfig parameters

Migration:
Before: new TrivuleForm(element, config)
After: new TrivuleForm().setConfig(element, config)

# Pull Request Template

## Description

Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.

### Related Issue

Closes #<issue number>

### Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Other

### Checklist

- [ ] Tests added/updated
- [ ] Breaking changes documented

## Additional Notes
