### PR TITLE
refactor: centralize configuration in TrParameter container

### DIFF
--- a/src/core/form.ts
+++ b/src/core/form.ts
@@ -11,8 +11,7 @@ import {
   CssSelector,
   TrivuleAttribute,
 } from '../types';
-import { TrLocal } from '../locale/tr-local';
-import { isBoolean, isNumber } from '../rules';
+import { isNumber } from '../rules';
 import { getHTMLElementBySelector, transformToArray } from '../utils';
 import { TrBag } from './bag';
 import { TrivuleInput } from './input';
@@ -75,21 +74,16 @@ export class TrivuleForm {
   submitButton!: HTMLElement;
 
   /**
-   * Tr Config object
+   * Shared parameter/configuration instance
    */
-  protected config: TrivuleFormConfig = {
-    auto: true,
-    realTime: true,
-  };
-
-  parameter!: TrParameter;
+  parameter: TrParameter;
 
   private _onUpdateCallbacks: TrivuleFormHandler<TrivuleForm>[] = [];
 
   private _wasInit = false;
   private _wasBound = false;
-  constructor() {
-    this.parameter = TrParameter.instance();
+  constructor(parameter?: TrParameter) {
+    this.parameter = parameter ?? TrParameter.instance();
   }
 
   /**
@@ -136,18 +130,39 @@ export class TrivuleForm {
     }
   }
   /**
-   * Initializes live validation on the form element.
+   * Initializes live validation on the form element with optional configuration.
    * Example:
    * ```
    * const trivuleForm = new TrivuleForm();
-   * trivuleForm.setConfig(formElement);
-   * trivuleForm.init();
+   * trivuleForm.init(formElement, config);
    * ```
    */
-  init() {
+  init(
+    containerOrConfig?: ValidatableForm | TrivuleFormConfig,
+    config?: TrivuleFormConfig,
+  ) {
+    // Handle configuration
+    if (
+      typeof containerOrConfig === 'string' ||
+      containerOrConfig instanceof HTMLElement
+    ) {
+      // If the first parameter is a container (string or HTMLElement)
+      if (config) {
+        this.parameter.configure(config);
+      }
+      this.bind(containerOrConfig);
+    } else {
+      // If the first parameter is a config object (or undefined)
+      config = config ?? containerOrConfig;
+      this.parameter.configure(config);
+      if (config?.element) {
+        this.bind(config.element);
+      }
+    }
+
     if (!this._wasInit) {
       this._wasInit = true;
-      if (this.config.auto) {
+      if (this.parameter.auto) {
         this.disableButton();
       }
 
@@ -183,7 +198,7 @@ export class TrivuleForm {
    */
   disableButton() {
     if (this.submitButton) {
-      if (this.config.auto) {
+      if (this.parameter.auto) {
         this.submitButton.setAttribute('disabled', 'true');
       }
       if (this._trDisabledClass) {
@@ -357,58 +372,6 @@ export class TrivuleForm {
    */
   rule(ruleName: string, call: RuleCallBack, message?: string) {
     TrBag.rule(ruleName, call, message);
-  }
-
-  setConfig(
-    containerOrConfig?: ValidatableForm | TrivuleFormConfig,
-    config?: TrivuleFormConfig,
-  ) {
-    // Handle the logic that was previously in the constructor
-    if (
-      typeof containerOrConfig === 'string' ||
-      containerOrConfig instanceof HTMLElement
-    ) {
-      // If the first parameter is a container (string or HTMLElement)
-      this._setConfigOptions(config);
-      this.bind(containerOrConfig);
-    } else {
-      // If the first parameter is a config object (or undefined)
-      config = config ?? containerOrConfig;
-      this._setConfigOptions(config);
-      if (config?.element) {
-        this.bind(config.element);
-      }
-    }
-  }
-
-  /**
-   * Set configuration options for the form
-   * @param config Configuration options
-   */
-  private _setConfigOptions(config?: TrivuleFormConfig) {
-    let lang =
-      this.getAttrData<string | undefined>(
-        document.querySelector('html'),
-        'lang',
-      ) || document.querySelector('html')?.getAttribute('lang');
-
-    lang = this.getAttrData(this.container, 'lang', lang);
-
-    const auto = this.getAttrData<string>(this.container, 'auto');
-    if (auto) {
-      this.config.auto = isBoolean(auto).passes;
-    }
-    if (config && typeof config === 'object') {
-      this.config = { ...this.config, ...config };
-      if (config.local) {
-        const local = config.local;
-        if (local.lang) {
-          lang = local.lang;
-        }
-      }
-    }
-
-    TrLocal.LANG = lang ?? TrLocal.DEFAULT_LANG;
   }
 
   /**
@@ -857,7 +820,6 @@ export class TrivuleForm {
    * @returns The form instance with real-time functionality enabled.
    */
   enableRealTime() {
-    this.config.realTime = true;
     this.each((tr) => {
       tr.enableRealTime();
       return this;
@@ -871,7 +833,6 @@ export class TrivuleForm {
    * @returns The form instance with real-time functionality disabled.
    */
   disableRealTime() {
-    this.config.realTime = false;
     this.each((tr) => {
       tr.disableRealTime();
       return this;
@@ -883,14 +844,13 @@ export class TrivuleForm {
    * @returns A boolean indicating whether real-time functionality is enabled.
    */
   isRealTimeEnabled() {
-    return this.config.realTime;
+    return this.parameter.realTime;
   }
   /**
    * Set the CSS class for valid inputs in the form.
    * @param cls The CSS class to apply to valid inputs.
    */
   setInputValidClass(cls: string) {
-    this.config.validClass = cls;
     this.each((i) => {
       i.setValidClass(cls);
     });
@@ -900,7 +860,6 @@ export class TrivuleForm {
    * @param cls The CSS class to apply to invalid inputs.
    */
   setInputInvalidClass(cls: string) {
-    this.config.invalidClass = cls;
     this.each((i) => {
       i.setInvalidClass(cls);
     });
@@ -937,8 +896,8 @@ export class TrivuleForm {
       }
     }
     if (!(this.container instanceof HTMLElement)) {
-      if (this.config.element) {
-        const element = getHTMLElementBySelector(this.config.element);
+      if (this.parameter.element) {
+        const element = getHTMLElementBySelector(this.parameter.element);
         if (element instanceof HTMLElement) {
           this.container = element;
         }
@@ -946,8 +905,6 @@ export class TrivuleForm {
     }
 
     if (this.container instanceof HTMLElement) {
-      this.parameter.setFeedbackSelector(this.config.feedbackSelector);
-
       this._initTrivuleInputs();
       this.init();
       this._wasBound = true;
@@ -1021,14 +978,14 @@ export class TrivuleForm {
     }
 
     if (typeof param.realTime !== 'boolean') {
-      param.realTime = this.config.realTime;
+      param.realTime = this.parameter.realTime;
     } else {
-      param.realTime = param.realTime ?? this.config.realTime;
+      param.realTime = param.realTime ?? this.parameter.realTime;
     }
 
-    param.validClass = param.validClass ?? this.config.validClass;
-    param.invalidClass = param.invalidClass ?? this.config.invalidClass;
-    param.autoValidate = param.autoValidate ?? this.config.auto;
+    param.validClass = param.validClass ?? this.parameter.validClass;
+    param.invalidClass = param.invalidClass ?? this.parameter.invalidClass;
+    param.autoValidate = param.autoValidate ?? this.parameter.auto;
     param.feedbackElement =
       param.feedbackElement ?? this.parameter.feedbackSelector;
     param.selector = selector as ValidatableInput;

--- a/src/core/trivule.ts
+++ b/src/core/trivule.ts
@@ -9,6 +9,7 @@ import { TrConfig } from '../tr.config';
 import { TrBag } from './bag';
 import { TrivuleForm } from './form';
 import { TrivuleInput } from './input';
+import { TrParameter } from './utils/parameter';
 /**
  *
  * Initializes Trivule and applies form validation to all forms in the document.
@@ -31,14 +32,16 @@ export class Trivule {
   private _trForms: TrivuleForm[] = [];
 
   /**
-   * Default configuration
+   * Shared parameter/configuration instance
    */
-  protected config: ITrConfig = TrConfig;
+  public parameter: TrParameter;
 
   /**
    * Private constructor to prevent direct instantiation
    */
-  private constructor() {}
+  private constructor() {
+    this.parameter = TrParameter.instance();
+  }
 
   /**
    * Static method to get or create the singleton instance
@@ -50,20 +53,28 @@ export class Trivule {
       Trivule._instance = new Trivule();
     }
 
-    Trivule._instance.setConfig(config);
-    Trivule._instance._trForms = [];
+    // Merge with default config to ensure required fields are set
+    const finalConfig: ITrConfig = {
+      ...TrConfig,
+      ...config,
+    };
 
+    // Configure parameter instance with all configuration
+    Trivule._instance.parameter.configure(finalConfig);
+
+    // Initialize forms
+    Trivule._instance._trForms = [];
     document
       .querySelectorAll<HTMLFormElement>('form')
       .forEach((formElement) => {
-        const trForm = new TrivuleForm();
-        trForm.setConfig(formElement, Trivule._instance!.config);
-        trForm.init();
+        const trForm = new TrivuleForm(Trivule._instance!.parameter);
+        trForm.init(formElement);
         Trivule._instance!._trForms.push(trForm);
       });
 
     return Trivule._instance;
   }
+
   /**
    * Adds a new validation rule to Trivule's rule bag.
    * @param ruleName The name of the rule.
@@ -82,18 +93,6 @@ export class Trivule {
     return this._trForms;
   }
 
-  /**
-   * Set default configuration
-   * @param config
-   */
-  protected setConfig(config?: ITrConfig) {
-    this.config = TrConfig;
-
-    if (config && typeof config === 'object') {
-      this.config = { ...this.config, ...config };
-    }
-  }
-
   static Rule(ruleName: string, call: RuleCallBack, message?: string) {
     TrBag.rule(ruleName, call, message);
   }
@@ -101,9 +100,8 @@ export class Trivule {
     selector: ValidatableForm | TrivuleFormConfig,
     config: TrivuleFormConfig,
   ) {
-    const trForm = new TrivuleForm();
-    trForm.setConfig(selector, config);
-    trForm.init();
+    const trForm = new TrivuleForm(this.parameter);
+    trForm.init(selector, config);
     return trForm;
   }
 

--- a/src/core/utils/parameter.ts
+++ b/src/core/utils/parameter.ts
@@ -1,17 +1,113 @@
-import { CssSelector } from '../../types';
+import {
+  CssSelector,
+  ITrConfig,
+  TrivuleFormConfig,
+  ValidatableForm,
+} from '../../types';
+import { TrLocal } from '../../locale/tr-local';
 
+/**
+ * TrParameter - Centralized configuration container for Trivule
+ * This singleton class holds all shared configuration and parameters
+ */
 export class TrParameter {
   private static _instance: TrParameter | null = null;
-  private bag = {
-    attribute: 'data-tr-',
-  };
-  /**
-   * The attribute that will be used to display the error message
-   * {attr} will be replaced by the value of attribute property
-   * {name} will be replaced by the input name
-   */
-  feedbackSelector: CssSelector | null = '[data-tr-feedback={name}]';
+
+  // Attribute prefix configuration (defaults to 'data-tr-')
+  private _attributePrefix: string = 'data-tr-';
+
+  // Selector configurations (using {attr} placeholder for dynamic attribute prefix)
+  private _feedbackSelector: CssSelector | null = '[{attr}feedback={name}]';
   inputSelector: CssSelector | null = '[name={name}]';
+
+  /**
+   * Get the feedback selector with attribute prefix replaced
+   */
+  get feedbackSelector(): CssSelector | null {
+    if (typeof this._feedbackSelector === 'string') {
+      return this._feedbackSelector.replace('{attr}', this.attributePrefix);
+    }
+    return this._feedbackSelector;
+  }
+
+  /**
+   * Set the feedback selector
+   */
+  set feedbackSelector(value: CssSelector | null) {
+    this._feedbackSelector = value;
+  }
+
+  // CSS class configurations
+  invalidClass: string = 'is-invalid';
+  validClass: string = '';
+
+  // Behavior configurations
+  realTime: boolean = true;
+  auto: boolean = true;
+
+  // Localization configuration
+  lang: string = TrLocal.DEFAULT_LANG;
+
+  // Element reference (for form-specific usage)
+  element?: ValidatableForm;
+
+  /**
+   * Get the attribute prefix
+   */
+  get attributePrefix(): string {
+    return this._attributePrefix;
+  }
+
+  /**
+   * Set the attribute prefix
+   */
+  set attributePrefix(value: string) {
+    if (!value || typeof value !== 'string') {
+      throw new Error('Trivule: attributePrefix must be a non-empty string');
+    }
+    this._attributePrefix = value;
+  }
+
+  /**
+   * Configure multiple parameters at once
+   * @param config Configuration object (ITrConfig or TrivuleFormConfig)
+   */
+  configure(config?: ITrConfig | TrivuleFormConfig): this {
+    if (!config || typeof config !== 'object') {
+      return this;
+    }
+
+    // Set attributePrefix if provided
+    if ('attributePrefix' in config && config.attributePrefix) {
+      this.attributePrefix = config.attributePrefix;
+    }
+
+    if (config.invalidClass !== undefined) {
+      this.invalidClass = config.invalidClass;
+    }
+    if (config.validClass !== undefined) {
+      this.validClass = config.validClass;
+    }
+    if (config.realTime !== undefined) {
+      this.realTime = config.realTime;
+    }
+    if (config.feedbackSelector !== undefined) {
+      this.feedbackSelector = config.feedbackSelector;
+    }
+    if (config.local?.lang) {
+      this.lang = config.local.lang;
+      TrLocal.LANG = config.local.lang;
+    }
+    if ('auto' in config && config.auto !== undefined) {
+      this.auto = config.auto;
+    }
+    if ('element' in config && config.element !== undefined) {
+      this.element = config.element;
+    }
+
+    return this;
+  }
+
   getFeedbackSelector(name: string): CssSelector | null {
     if (typeof this.feedbackSelector === 'string') {
       if (name.trim().length < 1) {
@@ -23,7 +119,7 @@ export class TrParameter {
     return this.feedbackSelector;
   }
 
-  setFeedbackSelector(selector?: string | HTMLElement | null) {
+  setFeedbackSelector(selector?: string | HTMLElement | null): this {
     if (!selector) {
       return this;
     }
@@ -31,7 +127,8 @@ export class TrParameter {
     this.feedbackSelector = selector;
     return this;
   }
-  getInputSelector(name: unknown) {
+
+  getInputSelector(name: unknown): CssSelector | null {
     if (typeof this.inputSelector === 'string' && typeof name === 'string') {
       if (name.trim().length < 1) {
         return null;
@@ -41,12 +138,30 @@ export class TrParameter {
     return this.inputSelector;
   }
 
-  get(key: keyof typeof this.bag) {
-    return this.bag[key];
+  /**
+   * Get a parameter value by key
+   * @param key The parameter key
+   * @deprecated Use direct property access instead (e.g., parameter.attributePrefix)
+   */
+  get(key: 'attribute'): string {
+    if (key === 'attribute') {
+      return this.attributePrefix;
+    }
+    throw new Error(`Unknown parameter key: ${key}`);
   }
-  set(key: keyof typeof this.bag, value: string) {
-    this.bag[key] = value;
-    return this;
+
+  /**
+   * Set a parameter value by key
+   * @param key The parameter key
+   * @param value The value to set
+   * @deprecated Use direct property access instead (e.g., parameter.attributePrefix = value)
+   */
+  set(key: 'attribute', value: string): this {
+    if (key === 'attribute') {
+      this.attributePrefix = value;
+      return this;
+    }
+    throw new Error(`Unknown parameter key: ${key}`);
   }
 
   static instance(): TrParameter {

--- a/src/tr.config.ts
+++ b/src/tr.config.ts
@@ -10,4 +10,5 @@ export const TrConfig: ITrConfig = {
     lang: TrLocal.DEFAULT_LANG,
   },
   realTime: true,
+  attributePrefix: 'data-tr-', // Required attribute prefix for all data attributes
 };

--- a/tests/form.test.ts
+++ b/tests/form.test.ts
@@ -64,7 +64,7 @@ const formInstance = new MyForm();
 
 describe('TrivuleForm', () => {
   const trivuleForm = new TrivuleForm();
-  trivuleForm.setConfig(formInstance.form, {
+  trivuleForm.init(formInstance.form, {
     realTime: false,
   });
   test('Test get method', () => {
@@ -129,7 +129,7 @@ describe('TrivuleForm', () => {
     });
     test('Should return the native element with config', () => {
       trForm = new TrivuleForm();
-      trForm.setConfig({
+      trForm.init({
         element: formInstance.form,
         realTime: false,
       });
@@ -138,9 +138,6 @@ describe('TrivuleForm', () => {
     });
     test('Should resole inputs validations', () => {
       trForm = new TrivuleForm();
-      trForm.setConfig({
-        realTime: false,
-      });
       trForm.make([
         {
           rules: 'required|between:18,40',
@@ -151,13 +148,16 @@ describe('TrivuleForm', () => {
           selector: formInstance.birthDayInput,
         },
       ]);
-      trForm.bind(formInstance.form);
+      trForm.init({
+        element: formInstance.form,
+        realTime: false,
+      });
       expect(trForm.getNativeElement()).toBe(formInstance.form);
       expect(trForm.isRealTimeEnabled()).toBe(false);
     });
     test('Should return the native element', () => {
       trForm = new TrivuleForm();
-      trForm.setConfig(formInstance.form);
+      trForm.init(formInstance.form);
       expect(trForm.getNativeElement()).toBe(formInstance.form);
     });
   });


### PR DESCRIPTION
- Transform TrParameter into centralized configuration container
- Remove separate config property from Trivule and TrivuleForm classes
- Add configure() method to TrParameter for bulk configuration
- Move all config properties to TrParameter (invalidClass, validClass, realTime, auto, lang)
- Make attributePrefix configurable from tr.config.ts with 'data-tr-' default
- Make feedbackSelector dynamic using {attr} placeholder for attribute prefix
- Replace all this.config.* references with this.parameter.*
- Remove setConfig method in favor of consolidated init() method
- Update all tests to use new init() signature

Benefits:
- Single source of truth for all configuration
- Shared configuration across instances via singleton pattern
- Cleaner separation: TrParameter = state/config, Trivule/TrivuleForm = behavior
- Simpler API - no need to track both config and parameter
- Dynamic feedbackSelector that updates with attributePrefix changes