### PR TITLE
fix: ensure Trivule.init() configuration properly overrides TrParamet…

### DIFF
--- a/src/core/utils/parameter.ts
+++ b/src/core/utils/parameter.ts
@@ -14,8 +14,8 @@ import { escapeCssSelector } from '../../utils';
 export class TrParameter {
   private static _instance: TrParameter | null = null;
 
-  // Attribute prefix configuration (defaults to 'data-tr-')
-  private _attributePrefix: string = 'data-tr-';
+  // Attribute prefix configuration (no default - must be set via configure)
+  private _attributePrefix?: string;
 
   // Selector configurations (using {attr} placeholder for dynamic attribute prefix)
   private _feedbackSelector: CssSelector | null = '[{attr}feedback={name}]';
@@ -57,7 +57,7 @@ export class TrParameter {
    * Get the attribute prefix
    */
   get attributePrefix(): string {
-    return this._attributePrefix;
+    return this._attributePrefix || 'data-tr-';
   }
 
   /**

--- a/tests/attr-selector.test.ts
+++ b/tests/attr-selector.test.ts
@@ -84,4 +84,19 @@ describe('attrSelector with different prefixes', () => {
     const elements = document.querySelectorAll(selector);
     expect(elements.length).toBe(2);
   });
+
+  it('should properly override attributePrefix on init (issue #51)', () => {
+    // First init with custom prefix
+    const trivule1 = Trivule.init({ attributePrefix: 'data-custom-' });
+    expect(trivule1.parameter.attributePrefix).toBe('data-custom-');
+    const selector1 = attrSelector('rules');
+    expect(selector1).toBe('[data-custom-rules]');
+
+    // Second init with different prefix should override
+    const trivule2 = Trivule.init({ attributePrefix: 'v:' });
+    expect(trivule2.parameter.attributePrefix).toBe('v:');
+    const selector2 = attrSelector('rules');
+    expect(selector2).toContain('v');
+    expect(selector2).toContain('rules');
+  });
 });


### PR DESCRIPTION
…er defaults

Fixes #51

- Changed _attributePrefix from hardcoded default to optional property
- attributePrefix getter now returns fallback value if not set
- Ensures configure() method properly overrides on each init() call
- Added test case to verify configuration override behavior
