### PR TITLE
feat: custom rule message definition on the input

### DIFF
--- a/index.html
+++ b/index.html
@@ -29,9 +29,10 @@
           id="email"
           name="email"
           @v:rules="required|email"
-          @v:msg:email="Please provide a valid email"
+          @v:msg.required="Email obligatoire"
+          @v:msg.email="Please provide a valid email"
         />
-        <p @v:feedback="email" class="error-message"></p>
+        <p @v:feedback="email" class="is-invalid"></p>
       </div>
 
       <div>
@@ -42,6 +43,8 @@
           id="password"
           name="password"
           @v:rules="required|min:6"
+          @v:msg.required="Mot de passe obligatoire"
+          @v:msg.min="Champ obligatoire"
         />
         <p @v:feedback="password" class="is-invalid"></p>
       </div>

--- a/src/core/input.ts
+++ b/src/core/input.ts
@@ -9,7 +9,7 @@ import {
   TrivuleInputParms,
   ValidatableInput,
 } from '../types';
-import { getHTMLElementBySelector } from '../utils';
+import { getHTMLElementBySelector, ruleKey } from '../utils';
 import { InputRule } from './utils/input-rule';
 import { TrParameter } from './utils/parameter';
 import { validate } from './validate';
@@ -77,6 +77,8 @@ export class TrivuleInput {
    * The attribute name used in validation error messages
    */
   private _messageAttribute = '';
+
+  _validateCount = 0;
 
   private constructor(param: TrivuleInputParms, parameter: TrParameter) {
     this.parameter = parameter;
@@ -167,8 +169,6 @@ export class TrivuleInput {
     return input === this.inputElement;
   }
 
-  _validateCount = 0;
-
   /**
    * Private method to get attribute data from the input element
    * @param attribute - The TrivuleAttribute to get
@@ -177,7 +177,7 @@ export class TrivuleInput {
    * @returns The attribute value or default
    */
   private getAttrData<T = unknown>(
-    attribute: TrivuleAttribute,
+    attribute: TrivuleAttribute | `msg.${Rule}` | string,
     defaults: unknown = null,
     toJson = false,
   ): T {
@@ -418,11 +418,11 @@ export class TrivuleInput {
   }
 
   /**
-	 * Sets whether validation should stop after the first error is encountered.
-	/**
-	 * Gets the feedback element associated with this Trivule input.
-	 * @returns The feedback element if set, otherwise null.
-	 */
+		 * Sets whether validation should stop after the first error is encountered.
+		/**
+		 * Gets the feedback element associated with this Trivule input.
+		 * @returns The feedback element if set, otherwise null.
+		 */
   getFeedbackElement() {
     return this.feedbackElement;
   }
@@ -484,9 +484,11 @@ export class TrivuleInput {
   get name() {
     return this.inputElement.name ?? this.param.name ?? '';
   }
+
   get value() {
     return this.getValue();
   }
+
   set value(value) {
     this._value = value;
     if (this.autoValidate) {
@@ -686,7 +688,7 @@ export class TrivuleInput {
   /**
    * Initializes the Trivule input instance.
    * This method sets up the input element from params, feedback element,
-   * validation rules, and event listeners for the input validation.
+   * validation rules,custom messages and event listeners for the input validation.
    *
    * @throws {Error} If the input element is not valid or cannot be found.
    */
@@ -704,17 +706,17 @@ export class TrivuleInput {
     this._setTrValidationClass();
 
     //Set the validation rules
-    const rules: string | string[] | Rule[] | undefined = this.getAttrData(
-      'rules',
-      this.param.rules,
-    );
+    const rules: string = this.getAttrData('rules', this.param.rules);
 
     if (rules) {
-      const elMessages = this.getAttrData<string>(
-        'messages',
-        this.param.messages,
-      );
-      this.rules.set(rules, elMessages);
+      const customMessages: Record<string, string> | null = {};
+
+      ruleKey(rules).forEach((rule) => {
+        const message: string = this.getAttrData(`msg.${rule}`);
+        customMessages[rule] = message;
+      });
+
+      this.rules.set(rules, customMessages);
     }
 
     this._type = (this.param.type ?? 'text') as InputType;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -260,10 +260,10 @@ export const escapeCssSelector = (str: string): string => {
  * @example
  * ```typescript
  * element.setAttribute(attr('rules'), 'required');
- * // Equivalent to: element.setAttribute('data-tr-rules', 'required')
+ * // Equivalent to: element.setAttribute('@v:rules', 'required')
  *
  * element.setAttribute(attr('feedback'), 'email');
- * // Equivalent to: element.setAttribute('data-tr-feedback', 'email')
+ * // Equivalent to: element.setAttribute('@v:feedback', 'email')
  * ```
  */
 export const attr = (name: string): string => {
@@ -289,4 +289,21 @@ export const attrSelector = (name: string): string => {
   const prefix = config('attributePrefix') as string;
   const escapedAttr = escapeCssSelector(`${prefix}${name}`);
   return `[${escapedAttr}]`;
+};
+
+/**
+ * Extracts rule keys from a pipe-separated rules string.
+ * @param {string} rulesString - The rules string (e.g., "required|min:6|max:20")
+ * @returns {Rule[] & string} Array of rule keys
+ * @example
+ * getRuleKey("required|min:6");
+ * // Returns: ["required", "min"]
+ *
+ * @example
+ * getRuleKey("email|min:5|max:255");
+ * // Returns: ["email", "min", "max"]
+ */
+export const ruleKey = (rulesString: string): (Rule & string)[] => {
+  return rulesString.split('|').map((rule) => rule.split(':')[0]) as (Rule &
+    string)[];
 };

--- a/tests/input.test.ts
+++ b/tests/input.test.ts
@@ -5,270 +5,255 @@ import { attr } from '../src/utils';
 
 // Helper function to create TrivuleInput for tests
 const createTrivuleInput = (inputElement: HTMLElement, params: any = {}) => {
-  // Add the inputElement as selector for the new API
-  const inputParams = {
-    selector: inputElement,
-    ...params,
-  };
-  return TrivuleInput.create(inputParams, TrParameter.instance());
+	// Add the inputElement as selector for the new API
+	const inputParams = {
+		selector: inputElement,
+		...params,
+	};
+	return TrivuleInput.create(inputParams, TrParameter.instance());
 };
 
 describe('TrivuleInput', () => {
-  describe('getRules', () => {
-    test('should return an array of rules for a given input field', () => {
-      // Arrange
-      const inputElement = document.createElement('input'); // Create an input element
-      inputElement.setAttribute(attr('rules'), 'required|min:30'); // Set rules for the input element
-      const rules = [
-        { name: 'required', message: 'This field is required' },
-        {
-          message: "The :field field must be greater than or equal to ':arg0'",
-          name: 'min',
-          params: '30',
-        },
-      ];
-      const validator = createTrivuleInput(inputElement);
+	describe('getRules', () => {
+		test('should return an array of rules for a given input field', () => {
+			// Arrange
+			const inputElement = document.createElement('input'); // Create an input element
+			inputElement.setAttribute(attr('rules'), 'required|min:30'); // Set rules for the input element
+			const rules = [
+				{ name: 'required', message: 'This field is required' },
+				{
+					message: "The :field field must be greater than or equal to ':arg0'",
+					name: 'min',
+					params: '30',
+				},
+			];
+			const validator = createTrivuleInput(inputElement);
 
-      expect(
-        validator.getRules().map((r) => {
-          return { name: r.name, message: r.message, params: r.params };
-        }),
-      ).toEqual(rules); // Assert that the result matches the expected rules array
-    });
+			expect(
+				validator.getRules().map((r) => {
+					return { name: r.name, message: r.message, params: r.params };
+				}),
+			).toEqual(rules); // Assert that the result matches the expected rules array
+		});
 
-    test('should return an empty array if no rules are set for a given input field', () => {
-      // Arrange
-      const inputElement = document.createElement('input');
-      const validator = createTrivuleInput(inputElement);
+		test('should return an empty array if no rules are set for a given input field', () => {
+			// Arrange
+			const inputElement = document.createElement('input');
+			const validator = createTrivuleInput(inputElement);
 
-      // Act
-      const result = validator.getRules(); // Call the getRules method
+			// Act
+			const result = validator.getRules(); // Call the getRules method
 
-      // Assert
-      expect(result).toEqual([]); // Assert that the result is an empty array
-    });
-  });
+			// Assert
+			expect(result).toEqual([]); // Assert that the result is an empty array
+		});
+	});
 
-  describe('hasRules', () => {
-    test('should return true if input have rules', () => {
-      const inputElement = document.createElement('input'); // Create an input element
-      inputElement.setAttribute(attr('rules'), 'required|min:30');
-      const validator = createTrivuleInput(inputElement);
-      expect(validator.hasRules()).toBe(true);
-    });
+	describe('hasRules', () => {
+		test('should return true if input have rules', () => {
+			const inputElement = document.createElement('input'); // Create an input element
+			inputElement.setAttribute(attr('rules'), 'required|min:30');
+			const validator = createTrivuleInput(inputElement);
+			expect(validator.hasRules()).toBe(true);
+		});
 
-    test('should return false if rules are empty', () => {
-      const inputElement = document.createElement('input');
-      const validator = createTrivuleInput(inputElement);
-      expect(validator.hasRules()).toBe(false); // Assert that the result is an empty array
-    });
-  });
+		test('should return false if rules are empty', () => {
+			const inputElement = document.createElement('input');
+			const validator = createTrivuleInput(inputElement);
+			expect(validator.hasRules()).toBe(false); // Assert that the result is an empty array
+		});
+	});
 
-  describe('getMessages', () => {
-    test('should return  messages set via tr-messages', () => {
-      const inputElement = document.createElement('input');
-      inputElement.setAttribute(attr('rules'), 'required|min:30');
-      inputElement.setAttribute(
-        attr('messages'),
-        'Required message | Min message',
-      );
-      const validator = createTrivuleInput(inputElement, {
-        failsOnfirst: false,
-      });
-      validator.validate();
-      const received = validator.getMessages();
-      expect(received).toEqual({
-        required: 'Required message',
-        min: 'Min message',
-      });
-    });
-    test('should return array of messages set via tr-messages with compensations messages', () => {
-      const inputElement = document.createElement('input');
-      inputElement.setAttribute(attr('rules'), 'required|min:30|max:60|email');
-      inputElement.setAttribute(
-        attr('messages'),
-        'Required message | {1,2,3}Invalid email address',
-      );
-      const validator = createTrivuleInput(inputElement, {
-        failsOnfirst: false,
-      });
+	describe('getMessages', () => {
+		test('should return  messages set via @v:mgs.<rule>', () => {
+			const inputElement = document.createElement('input');
+			inputElement.setAttribute(attr('rules'), 'required|min:30');
+			inputElement.setAttribute(
+				attr('msg.required'),
+				'Required message',
+			);
+			inputElement.setAttribute(
+				attr('msg.min'),
+				'Min message',
+			);
+			const validator = createTrivuleInput(inputElement, {
+				failsOnfirst: false,
+			});
+			validator.validate();
+			const received = validator.getMessages();
+			expect(received).toEqual({
+				required: 'Required message',
+				min: 'Min message',
+			});
+		});
 
-      validator.validate();
-      expect(validator.getMessages()).toEqual({
-        required: 'Required message',
-        min: 'Invalid email address',
-        max: 'Invalid email address',
-        email: 'Invalid email address',
-      });
-    });
+		test('should return false if rules are empty', () => {
+			// Arrange
+			const inputElement = document.createElement('input');
+			const validator = createTrivuleInput(inputElement);
 
-    test('should return false if rules are empty', () => {
-      // Arrange
-      const inputElement = document.createElement('input');
-      const validator = createTrivuleInput(inputElement);
+			expect(validator.hasRules()).toBe(false);
+		});
+	});
+	describe('valid', () => {
+		test('should return true if input is valid', () => {
+			// Arrange
+			const inputElement = document.createElement('input');
+			inputElement.setAttribute(
+				attr('rules'),
+				'required|min:2|regex:^(Js&pip;Ts)$',
+			);
+			inputElement.value = 'Js'; // Set the input value
+			const validator = createTrivuleInput(inputElement);
 
-      expect(validator.hasRules()).toBe(false); // Assert that the result is an empty array
-    });
-  });
-  describe('valid', () => {
-    test('should return true if input is valid', () => {
-      // Arrange
-      const inputElement = document.createElement('input');
-      inputElement.setAttribute(
-        attr('rules'),
-        'required|min:2|regex:^(Js&pip;Ts)$',
-      );
-      inputElement.value = 'Js'; // Set the input value
-      const validator = createTrivuleInput(inputElement);
+			expect(validator.valid()).toBe(true); // Assert that the input is valid
+		});
 
-      expect(validator.valid()).toBe(true); // Assert that the input is valid
-    });
+		test('should return false if input is invalid', () => {
+			// Arrange
+			const inputElement = document.createElement('input');
+			inputElement.setAttribute(attr('rules'), 'required|min:3');
+			inputElement.value = ''; // Set the input value to empty
+			const validator = createTrivuleInput(inputElement);
 
-    test('should return false if input is invalid', () => {
-      // Arrange
-      const inputElement = document.createElement('input');
-      inputElement.setAttribute(attr('rules'), 'required|min:3');
-      inputElement.value = ''; // Set the input value to empty
-      const validator = createTrivuleInput(inputElement);
+			expect(validator.valid()).toBe(false); // Assert that the input is invalid
+		});
+	});
 
-      expect(validator.valid()).toBe(false); // Assert that the input is invalid
-    });
-  });
+	describe('validate', () => {
+		test('should return true if input is valid', () => {
+			// Arrange
+			const inputElement = document.createElement('input');
+			inputElement.setAttribute(attr('rules'), 'required|min:3');
+			inputElement.value = 'test'; // Set the input value
+			const validator = createTrivuleInput(inputElement);
+			vi.spyOn(validator as any, 'setValidationClass').mockImplementation(
+				() => { },
+			); // Mock setValidationClass to prevent side effects
 
-  describe('validate', () => {
-    test('should return true if input is valid', () => {
-      // Arrange
-      const inputElement = document.createElement('input');
-      inputElement.setAttribute(attr('rules'), 'required|min:3');
-      inputElement.value = 'test'; // Set the input value
-      const validator = createTrivuleInput(inputElement);
-      vi.spyOn(validator as any, 'setValidationClass').mockImplementation(
-        () => {},
-      ); // Mock setValidationClass to prevent side effects
+			const result = validator.validate();
 
-      const result = validator.validate();
+			expect(result).toBe(true); // Assert that the input is valid
+		});
 
-      expect(result).toBe(true); // Assert that the input is valid
-    });
+		test('should return false if input is invalid', () => {
+			// Arrange
+			const inputElement = document.createElement('input');
+			inputElement.setAttribute(attr('rules'), 'required|min:3');
+			inputElement.value = ''; // Set the input value to empty
+			const validator = createTrivuleInput(inputElement);
+			vi.spyOn(validator as any, 'setValidationClass').mockImplementation(
+				() => { },
+			); // Mock setValidationClass to prevent side effects
 
-    test('should return false if input is invalid', () => {
-      // Arrange
-      const inputElement = document.createElement('input');
-      inputElement.setAttribute(attr('rules'), 'required|min:3');
-      inputElement.value = ''; // Set the input value to empty
-      const validator = createTrivuleInput(inputElement);
-      vi.spyOn(validator as any, 'setValidationClass').mockImplementation(
-        () => {},
-      ); // Mock setValidationClass to prevent side effects
+			// Act
+			const result = validator.validate();
 
-      // Act
-      const result = validator.validate();
+			// Assert
+			expect(result).toBe(false); // Assert that the input is invalid
+		});
+	});
 
-      // Assert
-      expect(result).toBe(false); // Assert that the input is invalid
-    });
-  });
+	describe('getErrors', () => {
+		test('should return error messages', () => {
+			// Arrange
+			const inputElement = document.createElement('input');
+			inputElement.setAttribute(attr('rules'), 'required|min:3');
+			inputElement.name = 'input-name';
+			inputElement.value = ''; // Set the input value to empty
+			inputElement.type = 'text';
+			const validator = createTrivuleInput(inputElement);
 
-  describe('getErrors', () => {
-    test('should return error messages', () => {
-      // Arrange
-      const inputElement = document.createElement('input');
-      inputElement.setAttribute(attr('rules'), 'required|min:3');
-      inputElement.name = 'input-name';
-      inputElement.value = ''; // Set the input value to empty
-      inputElement.type = 'text';
-      const validator = createTrivuleInput(inputElement);
+			vi.spyOn(validator as any, 'setValidationClass').mockImplementation(
+				() => { },
+			); // Mock setValidationClass to prevent side effects
 
-      vi.spyOn(validator as any, 'setValidationClass').mockImplementation(
-        () => {},
-      ); // Mock setValidationClass to prevent side effects
+			validator.validate();
+			const result = validator.errors;
 
-      validator.validate();
-      const result = validator.errors;
+			expect(result).toEqual({
+				required: 'This field is required',
+				min: 'The minimum number of allowed characters is: 3',
+			});
+		});
 
-      expect(result).toEqual({
-        required: 'This field is required',
-        min: 'The minimum number of allowed characters is: 3',
-      });
-    });
+		test('should return empty error messages', () => {
+			// Arrange
+			const inputElement = document.createElement('input');
+			inputElement.setAttribute(attr('rules'), 'required|min:3');
+			inputElement.type = 'number';
+			inputElement.name = 'name-empty';
+			inputElement.value = '4';
+			const validator = createTrivuleInput(inputElement);
 
-    test('should return empty error messages', () => {
-      // Arrange
-      const inputElement = document.createElement('input');
-      inputElement.setAttribute(attr('rules'), 'required|min:3');
-      inputElement.type = 'number';
-      inputElement.name = 'name-empty';
-      inputElement.value = '4';
-      const validator = createTrivuleInput(inputElement);
+			vi.spyOn(validator as any, 'setValidationClass').mockImplementation(
+				() => { },
+			); // Mock setValidationClass to prevent side effects
 
-      vi.spyOn(validator as any, 'setValidationClass').mockImplementation(
-        () => {},
-      ); // Mock setValidationClass to prevent side effects
+			validator.validate();
+			const result = validator.errors;
 
-      validator.validate();
-      const result = validator.errors;
+			expect(result).toEqual({});
+		});
+	});
 
-      expect(result).toEqual({});
-    });
-  });
+	describe('setFeedbackElement', () => {
+		const body = document.createElement('div');
+		const inputElement = document.createElement('input');
+		const feedbackElement = document.createElement('div');
+		body.appendChild(inputElement);
+		body.appendChild(feedbackElement);
+		const validator = createTrivuleInput(inputElement);
+		test('should return the feedback element supplied througth the set method', () => {
+			validator.setFeedbackElement(feedbackElement);
+			expect(validator.getFeedbackElement() === feedbackElement).toBe(true);
+		});
 
-  describe('setFeedbackElement', () => {
-    const body = document.createElement('div');
-    const inputElement = document.createElement('input');
-    const feedbackElement = document.createElement('div');
-    body.appendChild(inputElement);
-    body.appendChild(feedbackElement);
-    const validator = createTrivuleInput(inputElement);
-    test('should return the feedback element supplied througth the set method', () => {
-      validator.setFeedbackElement(feedbackElement);
-      expect(validator.getFeedbackElement() === feedbackElement).toBe(true);
-    });
+		test('should return true if no feedback element found', () => {
+			inputElement.name = 'my-input';
+			feedbackElement.setAttribute(attr('feedback'), 'my-input');
+			validator.setFeedbackElement('no-select');
 
-    test('should return true if no feedback element found', () => {
-      inputElement.name = 'my-input';
-      feedbackElement.setAttribute(attr('feedback'), 'my-input');
-      validator.setFeedbackElement('no-select');
+			expect(validator.getFeedbackElement() === null).toBe(true);
+		});
 
-      expect(validator.getFeedbackElement() === null).toBe(true);
-    });
+		test('should return the feedback element supplied througth the attribute', () => {
+			inputElement.name = 'my-input';
+			feedbackElement.setAttribute(attr('feedback'), 'my-input');
+			validator.setFeedbackElement();
 
-    test('should return the feedback element supplied througth the attribute', () => {
-      inputElement.name = 'my-input';
-      feedbackElement.setAttribute(attr('feedback'), 'my-input');
-      validator.setFeedbackElement();
+			expect(validator.getFeedbackElement() === feedbackElement).toBe(true);
+		});
+	});
 
-      expect(validator.getFeedbackElement() === feedbackElement).toBe(true);
-    });
-  });
+	describe('$rules', () => {
+		const inputElement = document.createElement('input');
+		const trivuleInput = createTrivuleInput(inputElement, {
+			rules: 'required',
+		});
+		test('should set the message', () => {
+			trivuleInput.$rules.set('required', 'test');
+			expect(trivuleInput.$rules.getMessage('required')).toBe('test');
+		});
+	});
+	describe('setRules', () => {
+		test('should set rules to the inputs', () => {
+			const input = document.createElement('input');
+			const trivuleInput = createTrivuleInput(input, {
+				rules: 'required',
+			});
 
-  describe('$rules', () => {
-    const inputElement = document.createElement('input');
-    const trivuleInput = createTrivuleInput(inputElement, {
-      rules: 'required',
-    });
-    test('should set the message', () => {
-      trivuleInput.$rules.set('required', 'test');
-      expect(trivuleInput.$rules.getMessage('required')).toBe('test');
-    });
-  });
-  describe('setRules', () => {
-    test('should set rules to the inputs', () => {
-      const input = document.createElement('input');
-      const trivuleInput = createTrivuleInput(input, {
-        rules: 'required',
-      });
+			trivuleInput.setRules('min:2').setRules(['email', 'digit:3']);
+			const received = trivuleInput.getRules().map((r) => r.name);
+			expect(received).toEqual(['required', 'min', 'email', 'digit']);
+		});
+	});
 
-      trivuleInput.setRules('min:2').setRules(['email', 'digit:3']);
-      const received = trivuleInput.getRules().map((r) => r.name);
-      expect(received).toEqual(['required', 'min', 'email', 'digit']);
-    });
-  });
-
-  describe('getInputElement', () => {
-    test('should return the input element', () => {
-      const inputElement = document.createElement('input');
-      const trivuleInput = createTrivuleInput(inputElement);
-      expect(trivuleInput.getInputElement()).toBe(inputElement);
-    });
-  });
+	describe('getInputElement', () => {
+		test('should return the input element', () => {
+			const inputElement = document.createElement('input');
+			const trivuleInput = createTrivuleInput(inputElement);
+			expect(trivuleInput.getInputElement()).toBe(inputElement);
+		});
+	});
 });


### PR DESCRIPTION
# Custom rule message defintion the input

## Description

You can override the error message for a specific rule with `@v:msg.<rule>`.

Eg:

```html
    <form @v:form>
      <div>
        <label for="email">Email:</label>
        <input
          id="email-1"
          type="text"
          id="email"
          name="email"
          @v:rules="required|email"
          @v:msg.required="Email obligatoire"
          @v:msg.email="Please provide a valid email"
        />
        <p @v:feedback="email" class="is-invalid"></p>
      </div>

      <div>
        <label for="password">Password:</label>
        <input
          id="password-1"
          type="password"
          id="password"
          name="password"
          @v:rules="required|min:6"
          @v:msg.required="Mot de passe obligatoire"
          @v:msg.min="Champ obligatoire"
        />
        <p @v:feedback="password" class="is-invalid"></p>
      </div>

      <button type="submit" @v:submit>Register</button>
    </form>


```


### Type of Change

- [ ] Bug fix
- [x] New feature
- [x] Breaking change
- [ ] Other

### Checklist

- [x] Tests added/updated
- [ ] Breaking changes documented

## Additional Notes
